### PR TITLE
fix: value range deprecation warning

### DIFF
--- a/src/timeitpkg/cli.nim
+++ b/src/timeitpkg/cli.nim
@@ -38,7 +38,7 @@ proc command*() =
     option = "debug"
 
   if name.endsWith(".nim"):
-    name = name[ .. ^5]
+    name = name[ 0 .. ^5]
   var strm = newFileStream(name & ".nim", fmRead)
   var line = ""
   let tempFile = getTempDir() & "timeit_temp.nim"


### PR DESCRIPTION
# Summary
replaced `.. ^5` to `0 .. ^5`

# Description
after installing the library from nimble, got following deprecation warning:
```
/tmp/nimble_47258/githubcom_ringabouttimeit/src/timeitpkg/cli.nim(42, 18) Warning: replace `..b` with `0..b`; .. is deprecated [Deprecated]
```
